### PR TITLE
Restore doc examples and revert to Sphinx-style docstrings

### DIFF
--- a/src/saml2/algsupport.py
+++ b/src/saml2/algsupport.py
@@ -39,15 +39,10 @@ SIGNING_METHODS = {
 def get_algorithm_support(xmlsec):
     """Query the xmlsec binary for supported digest and signing algorithms.
 
-    Args:
-        xmlsec: Path to the xmlsec1 binary.
-
-    Returns:
-        dict[str, list[str]]: Mapping of ``digest`` and ``signing`` algorithm
-        names recognised by xmlsec.
-
-    Raises:
-        SystemError: If xmlsec reports an error.
+    :param xmlsec: Path to the xmlsec1 binary.
+    :return: Mapping of ``digest`` and ``signing`` algorithm names recognised
+        by xmlsec.
+    :raises SystemError: If xmlsec reports an error.
     """
     com_list = [xmlsec, "--list-transforms"]
     pof = Popen(com_list, stderr=PIPE, stdout=PIPE)
@@ -74,12 +69,9 @@ def get_algorithm_support(xmlsec):
 def algorithm_support_in_metadata(xmlsec):
     """Represent xmlsec algorithm support as metadata extension elements.
 
-    Args:
-        xmlsec: Path to the xmlsec1 binary.
-
-    Returns:
-        list[SamlBase]: Digest and signing method elements suitable for
-        inclusion in metadata.
+    :param xmlsec: Path to the xmlsec1 binary.
+    :return: Digest and signing method elements suitable for inclusion in
+        metadata.
     """
     if xmlsec is None:
         return []

--- a/src/saml2/argtree.py
+++ b/src/saml2/argtree.py
@@ -1,27 +1,20 @@
-from typing import Any
-
-
 __author__ = "roland"
 
 
 def find_paths(cls, arg, path=None, seen=None, res=None, lev=0):
     """Discover attribute paths defined on a SAML class hierarchy.
 
-    Args:
-        cls: SAML class whose ``c_children`` and ``c_attributes`` metadata
-            should be traversed.
-        arg: Attribute or child name that should be located.
-        path: Accumulated path segments while descending the tree.
-        seen: Sequence of classes that have already been inspected to avoid
-            infinite recursion.
-        res: Mutable list that will be populated with discovered paths.
-        lev: Current recursion depth; used to initialise the ``res`` list on
-            the first invocation.
-
-    Returns:
-        list[list[str]] | None: When ``lev`` is zero a list of matching paths is
-        returned. For recursive calls, ``None`` is returned to keep the
-        traversal lightweight.
+    :param cls: SAML class whose ``c_children`` and ``c_attributes`` metadata
+        should be traversed.
+    :param arg: Attribute or child name that should be located.
+    :param path: Accumulated path segments while descending the tree.
+    :param seen: Sequence of classes that have already been inspected to avoid
+        infinite recursion.
+    :param res: Mutable list that will be populated with discovered paths.
+    :param lev: Current recursion depth; used to initialise ``res`` on the
+        first invocation.
+    :return: A list of matching paths when called from the top-level. Recursive
+        invocations return ``None`` to keep the traversal lightweight.
     """
     if lev == 0 and res is None:
         res = []
@@ -60,17 +53,13 @@ def find_paths(cls, arg, path=None, seen=None, res=None, lev=0):
 
 
 def set_arg(cls, arg, value):
-    """Build dictionaries that assign a value to every matching attribute.
+    """Build dictionaries that assign ``value`` to every matching attribute.
 
-    Args:
-        cls: SAML class whose metadata will be inspected.
-        arg: Attribute or child element name that should be set.
-        value: Value to assign at the terminal path element.
-
-    Returns:
-        list[dict[str, Any]]: One dictionary for each matching path. Each
-        dictionary contains nested structures that describe how to reach the
-        attribute from the root object.
+    :param cls: SAML class whose metadata will be inspected.
+    :param arg: Attribute or child element name that should be set.
+    :param value: Value to assign at the terminal path element.
+    :return: A list containing one dictionary per matching path. Each
+        dictionary describes how to reach the attribute from the root object.
     """
     res = []
     for path in find_paths(cls, arg):
@@ -85,19 +74,37 @@ def set_arg(cls, arg, value):
 
 
 def add_path(tdict, path):
-    """Create or extend an argument tree from a flattened path.
+    """Create or extend an argument tree ``tdict`` from ``path``.
 
-    The utility converts a list describing a traversal into a nested
-    dictionary structure. The second to last element becomes a key whose value
-    is the final path element. The remaining entries in ``path`` are turned
-    into intermediate dictionaries that capture the hierarchy.
+    :param tdict: A dictionary representing an argument tree.
+    :param path: A path list.
+    :return: A dictionary representing the updated argument tree.
 
-    Args:
-        tdict: Dictionary representing a partially built argument tree.
-        path: Iterable of path components describing how to reach an attribute.
+    Convert a list of items in a ``path`` into a nested dict, where the
+    second to last item becomes the key for the final item. The remaining
+    items in the path become keys in the nested dict around that final pair
+    of items.
 
-    Returns:
-        dict[str, Any]: The updated argument tree.
+    For example, for input values of::
+
+        tdict = {}
+        path = ['assertion', 'subject', 'subject_confirmation',
+                'method', 'urn:oasis:names:tc:SAML:2.0:cm:bearer']
+
+    returns the output::
+
+        {'assertion': {'subject': {'subject_confirmation':
+                      {'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'}}}}
+
+    Another example, this time with a non-empty ``tdict`` input::
+
+        tdict = {'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'}
+        path = ['subject_confirmation_data', 'in_response_to', '_012345']
+
+    returns the output::
+
+        {'subject_confirmation_data': {'in_response_to': '_012345'},
+         'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'}
     """
     t = tdict
     for step in path[:-2]:
@@ -114,13 +121,9 @@ def add_path(tdict, path):
 def is_set(tdict, path):
     """Determine whether a path inside an argument tree has a value.
 
-    Args:
-        tdict: Dictionary representing the argument tree.
-        path: Iterable of path segments describing the desired value.
-
-    Returns:
-        bool: ``True`` when a non-``None`` value exists at the supplied path;
-        otherwise ``False``.
+    :param tdict: A dictionary representing an argument tree.
+    :param path: A path list.
+    :return: ``True`` if the value is set, otherwise ``False``.
     """
     t = tdict
     for step in path:
@@ -138,12 +141,9 @@ def is_set(tdict, path):
 def get_attr(tdict, path):
     """Fetch the value located at ``path`` inside ``tdict``.
 
-    Args:
-        tdict: Dictionary representing the argument tree.
-        path: Iterable of keys describing the nested traversal.
-
-    Returns:
-        Any: Value stored at the end of ``path``.
+    :param tdict: A dictionary representing an argument tree.
+    :param path: A path list describing the nested traversal.
+    :return: The value stored at the end of ``path``.
     """
     t = tdict
     for step in path:

--- a/src/saml2/authn_context/__init__.py
+++ b/src/saml2/authn_context/__init__.py
@@ -54,22 +54,19 @@ class AuthnBroker:
     def add(self, spec, method, level=0, authn_authority="", reference=None):
         """Register a new authentication method for a given context.
 
-        Args:
-            spec: The advertised :class:`~saml2.saml.AuthnContext` or
-                declaration describing the method.
-            method: Identifier that the IdP uses internally when invoking the
-                authenticating mechanism.
-            level: Positive integer indicating the strength of the method where
-                a higher value represents a stronger assurance level.
-            authn_authority: Optional identifier of the upstream authority that
-                issues the authentication event.
-            reference: Optional explicit reference to store the configuration
-                under. A unique reference is generated automatically when not
-                supplied.
-
-        Raises:
-            Exception: If the generated or supplied reference collides with an
-                existing registration.
+        :param spec: The advertised :class:`~saml2.saml.AuthnContext` or
+            declaration describing the method.
+        :param method: Identifier that the IdP uses internally when invoking
+            the authenticating mechanism.
+        :param level: Positive integer indicating the strength of the method;
+            higher values represent a stronger assurance level.
+        :param authn_authority: Optional identifier of the upstream authority
+            that issues the authentication event.
+        :param reference: Optional explicit reference to store the
+            configuration under. A unique reference is generated automatically
+            when not supplied.
+        :raises Exception: If the generated or supplied reference collides with
+            an existing registration.
         """
 
         if spec.authn_context_class_ref:
@@ -98,15 +95,14 @@ class AuthnBroker:
     def remove(self, spec, method=None, level=0, authn_authority=""):
         """Remove registrations that match the provided constraints.
 
-        Args:
-            spec: The :class:`~saml2.saml.AuthnContext` describing the
-                registration to remove.
-            method: Optional identifier of the method to remove. When omitted
-                all methods for the context are considered.
-            level: Optional assurance level that must match an existing
-                registration to be removed.
-            authn_authority: Optional identifier of the authentication
-                authority to match before removal.
+        :param spec: The :class:`~saml2.saml.AuthnContext` describing the
+            registration to remove.
+        :param method: Optional identifier of the method to remove. When
+            omitted, all methods for the context are considered.
+        :param level: Optional assurance level that must match an existing
+            registration to be removed.
+        :param authn_authority: Optional identifier of the authentication
+            authority to match before removal.
         """
         if spec.authn_context_class_ref:
             _cls_ref = spec.authn_context_class_ref.text
@@ -130,16 +126,13 @@ class AuthnBroker:
     def _pick_by_class_ref(self, cls_ref, comparision_type="exact"):
         """Resolve methods for the given class reference and comparison type.
 
-        Args:
-            cls_ref: The SAML authentication context class reference URI to
-                match.
-            comparision_type: How to compare assurance levels. One of
-                ``"exact"``, ``"minimum"``, ``"maximum"`` or ``"better"``.
-
-        Returns:
-            list[tuple[str | None, str]]: Ordered list of pairs ``(method,
-            reference)`` describing matching registrations. Methods may be
-            ``None`` when only a declaration is available.
+        :param cls_ref: The SAML authentication context class reference URI to
+            match.
+        :param comparision_type: How to compare assurance levels. One of
+            ``"exact"``, ``"minimum"``, ``"maximum"`` or ``"better"``.
+        :return: An ordered list of ``(method, reference)`` pairs describing
+            matching registrations. Methods may be ``None`` when only a
+            declaration is available.
         """
         func = getattr(self, comparision_type)
         try:
@@ -175,14 +168,11 @@ class AuthnBroker:
     def pick(self, req_authn_context=None):
         """Return candidate authentication methods for a request.
 
-        Args:
-            req_authn_context: Requested context requirements provided by the
-                service provider. ``None`` defaults to the ``unspecified``
-                context.
-
-        Returns:
-            list[tuple[str | None, str]]: Ordered list of method references that
-            satisfy the request according to the requested comparison strategy.
+        :param req_authn_context: Requested context requirements provided by
+            the service provider. ``None`` defaults to the ``unspecified``
+            context.
+        :return: An ordered list of method references that satisfy the request
+            according to the requested comparison strategy.
         """
 
         if req_authn_context is None:
@@ -209,12 +199,9 @@ class AuthnBroker:
     def match(self, requested, provided):
         """Check whether a provided context fulfils a requested context.
 
-        Args:
-            requested: Requested authentication context identifier.
-            provided: Authentication context identifier delivered by the IdP.
-
-        Returns:
-            bool: ``True`` if the provided context satisfies the request.
+        :param requested: Requested authentication context identifier.
+        :param provided: Authentication context identifier delivered by the IdP.
+        :return: ``True`` if the provided context satisfies the request.
         """
 
         if requested == provided:
@@ -225,11 +212,8 @@ class AuthnBroker:
     def __getitem__(self, ref):
         """Retrieve the stored registration details for a reference.
 
-        Args:
-            ref: Registration reference identifier generated by :meth:`add`.
-
-        Returns:
-            dict: Stored metadata describing the authentication method.
+        :param ref: Registration reference identifier generated by :meth:`add`.
+        :return: Stored metadata describing the authentication method.
         """
 
         return self.db["info"][ref]
@@ -237,11 +221,8 @@ class AuthnBroker:
     def get_authn_by_accr(self, accr):
         """Return the first registration matching a class reference.
 
-        Args:
-            accr: Authentication context class reference URI.
-
-        Returns:
-            dict: The stored registration information for the first matching
+        :param accr: Authentication context class reference URI.
+        :return: The stored registration information for the first matching
             reference.
         """
 

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -172,8 +172,7 @@ class Config:
     def __init__(self, homedir="."):
         """Initialise the configuration with default values.
 
-        Args:
-            homedir: Base directory used for resolving relative file paths.
+        :param homedir: Base directory used for resolving relative file paths.
         """
 
         self.logging = None
@@ -242,10 +241,9 @@ class Config:
     def setattr(self, context, attr, val):
         """Set a configuration attribute for the given context.
 
-        Args:
-            context: Entity context (``""`` for common attributes).
-            attr: Attribute name to assign.
-            val: Value to assign.
+        :param context: Entity context (``""`` for common attributes).
+        :param attr: Attribute name to assign.
+        :param val: Value to assign.
         """
 
         if context == "":
@@ -256,12 +254,9 @@ class Config:
     def getattr(self, attr, context=None):
         """Retrieve a configuration attribute, falling back to defaults.
 
-        Args:
-            attr: Attribute name to look up.
-            context: Optional entity context to read from.
-
-        Returns:
-            Any: The stored value or ``None`` when undefined.
+        :param attr: Attribute name to look up.
+        :param context: Optional entity context to read from.
+        :return: The stored value or ``None`` when undefined.
         """
 
         if context is None:
@@ -275,9 +270,8 @@ class Config:
     def load_special(self, cnf, typ):
         """Populate role-specific configuration keys.
 
-        Args:
-            cnf: Service-specific configuration dictionary.
-            typ: Entity type key such as ``"idp"`` or ``"sp"``.
+        :param cnf: Service-specific configuration dictionary.
+        :param typ: Entity type key such as ``"idp"`` or ``"sp"``.
         """
 
         for arg in SPEC[typ]:
@@ -298,11 +292,8 @@ class Config:
     def load_complex(self, cnf):
         """Process configuration blocks that require additional setup.
 
-        Args:
-            cnf: Configuration dictionary.
-
-        Raises:
-            ConfigurationError: If attribute converters are missing.
+        :param cnf: Configuration dictionary.
+        :raises ConfigurationError: If attribute converters are missing.
         """
 
         acs = ac_factory(cnf.get("attribute_map_dir"))
@@ -322,13 +313,10 @@ class Config:
     def load(self, cnf, metadata_construction=None):
         """Load configuration data into the instance.
 
-        Args:
-            cnf: Configuration dictionary.
-            metadata_construction: Deprecated argument retained for backwards
-                compatibility. Passing a value triggers a warning.
-
-        Returns:
-            Config: The populated configuration instance.
+        :param cnf: Configuration dictionary.
+        :param metadata_construction: Deprecated argument retained for
+            backwards compatibility. Passing a value triggers a warning.
+        :return: The populated configuration instance.
         """
 
         if metadata_construction is not None:
@@ -390,11 +378,8 @@ class Config:
     def _load(self, fil):
         """Import a configuration module from a path or dotted name.
 
-        Args:
-            fil: Path or module name pointing to the configuration module.
-
-        Returns:
-            ModuleType: Imported module containing configuration data.
+        :param fil: Path or module name pointing to the configuration module.
+        :return: Imported module containing configuration data.
         """
 
         head, tail = os.path.split(fil)
@@ -409,16 +394,12 @@ class Config:
     def load_file(self, config_filename, metadata_construction=None):
         """Load configuration from a Python file or module.
 
-        Args:
-            config_filename: File path or module name to import.
-            metadata_construction: Deprecated argument retained for backwards
-                compatibility. Passing a value triggers a warning.
-
-        Returns:
-            Config: The populated configuration instance.
-
-        Raises:
-            ConfigurationError: If the module lacks a ``CONFIG`` dictionary.
+        :param config_filename: File path or module name to import.
+        :param metadata_construction: Deprecated argument retained for
+            backwards compatibility. Passing a value triggers a warning.
+        :return: The populated configuration instance.
+        :raises ConfigurationError: If the module lacks a ``CONFIG``
+            dictionary.
         """
 
         if metadata_construction is not None:
@@ -439,14 +420,9 @@ class Config:
     def load_metadata(self, metadata_conf):
         """Create and populate a metadata store for the configuration.
 
-        Args:
-            metadata_conf: Metadata configuration dictionary.
-
-        Returns:
-            MetadataStore: The populated metadata store.
-
-        Raises:
-            ConfigurationError: If attribute converters are missing.
+        :param metadata_conf: Metadata configuration dictionary.
+        :return: The populated metadata store.
+        :raises ConfigurationError: If attribute converters are missing.
         """
 
         acs = self.attribute_converters
@@ -475,14 +451,12 @@ class Config:
     def endpoint(self, service, binding=None, context=None):
         """Return endpoints matching the requested service and binding.
 
-        Args:
-            service: Service identifier, e.g. ``"single_sign_on_service"``.
-            binding: Optional SAML binding to restrict results to.
-            context: Optional entity context to use when selecting endpoints.
-
-        Returns:
-            list[str] | list[tuple[str, str]]: Exact endpoint URLs when binding
-            is matched, otherwise the unfiltered endpoint specifications.
+        :param service: Service identifier, e.g. ``"single_sign_on_service"``.
+        :param binding: Optional SAML binding to restrict results to.
+        :param context: Optional entity context to use when selecting
+            endpoints.
+        :return: Exact endpoint URLs when ``binding`` is provided, otherwise
+            the unfiltered endpoint specifications.
         """
         spec = []
         unspec = []
@@ -509,13 +483,10 @@ class Config:
     def endpoint2service(self, endpoint, context=None):
         """Look up the service and binding that expose a given endpoint.
 
-        Args:
-            endpoint: Endpoint URL to inspect.
-            context: Optional entity context.
-
-        Returns:
-            tuple[str | None, str | None]: The ``(service, binding)`` pair or
-            ``(None, None)`` when the endpoint is not found.
+        :param endpoint: Endpoint URL to inspect.
+        :param context: Optional entity context.
+        :return: The ``(service, binding)`` pair or ``(None, None)`` when the
+            endpoint is not found.
         """
         endps = self.getattr("endpoints", context)
 
@@ -529,8 +500,8 @@ class Config:
     def do_extensions(self, extensions):
         """Merge configured extensions into the global extensions store.
 
-        Args:
-            extensions: Mapping of extension identifier to configuration data.
+        :param extensions: Mapping of extension identifier to configuration
+            data.
         """
         for key, val in extensions.items():
             self.extensions[key] = val
@@ -538,12 +509,8 @@ class Config:
     def service_per_endpoint(self, context=None):
         """Return a mapping of endpoint URLs to their service and binding.
 
-        Args:
-            context: Optional entity context.
-
-        Returns:
-            dict[str, tuple[str, str]]: Mapping of endpoint URL to
-            ``(service, binding)`` tuples.
+        :param context: Optional entity context.
+        :return: Mapping of endpoint URL to ``(service, binding)`` tuples.
         """
         endps = self.getattr("endpoints", context)
         res = {}
@@ -562,11 +529,8 @@ class SPConfig(Config):
     def vo_conf(self, vo_name):
         """Return the virtual organisation configuration for a given name.
 
-        Args:
-            vo_name: Identifier of the virtual organisation.
-
-        Returns:
-            dict | None: The configuration dictionary or ``None`` if missing.
+        :param vo_name: Identifier of the virtual organisation.
+        :return: The configuration dictionary or ``None`` if missing.
         """
         try:
             return self.virtual_organization[vo_name]
@@ -576,11 +540,8 @@ class SPConfig(Config):
     def ecp_endpoint(self, ipaddress):
         """Resolve which IdP entity should be used for an ECP client.
 
-        Args:
-            ipaddress: IP address of the user agent.
-
-        Returns:
-            str | None: IdP entity ID or ``None`` when no rule matches.
+        :param ipaddress: IP address of the user agent.
+        :return: IdP entity ID or ``None`` when no rule matches.
         """
         _ecp = self.getattr("ecp")
         if _ecp:
@@ -602,15 +563,11 @@ class IdPConfig(Config):
 def config_factory(_type, config):
     """Instantiate and populate a configuration object for the given role.
 
-    Args:
-        _type: Entity type (``"sp"``, ``"idp"``, ``"aa"``, ``"pdp"`` or ``"aq"``).
-        config: Configuration dictionary or path to a configuration module.
-
-    Returns:
-        Config: A populated configuration instance scoped to ``_type``.
-
-    Raises:
-        ValueError: If ``config`` is neither a mapping nor a string path.
+    :param _type: Entity type (``"sp"``, ``"idp"``, ``"aa"``, ``"pdp"`` or
+        ``"aq"``).
+    :param config: Configuration dictionary or path to a configuration module.
+    :return: A populated configuration instance scoped to ``_type``.
+    :raises ValueError: If ``config`` is neither a mapping nor a string path.
     """
     if _type == "sp":
         conf = SPConfig()

--- a/src/saml2/cryptography/asymmetric.py
+++ b/src/saml2/cryptography/asymmetric.py
@@ -8,13 +8,9 @@ import cryptography.hazmat.primitives.serialization as _serialization
 def load_pem_private_key(data, password=None):
     """Load an RSA private key from PEM data.
 
-    Args:
-        data: PEM encoded key material.
-        password: Optional passphrase protecting the key.
-
-    Returns:
-        cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey: Loaded key
-        object.
+    :param data: PEM encoded key material.
+    :param password: Optional passphrase protecting the key.
+    :return: The loaded private key object.
     """
     key = _serialization.load_pem_private_key(data, password)
     return key
@@ -23,13 +19,10 @@ def load_pem_private_key(data, password=None):
 def key_sign(rsakey, message, digest):
     """Sign a message using PKCS#1 v1.5 padding.
 
-    Args:
-        rsakey: RSA private key used to sign the message.
-        message: Bytes payload to sign.
-        digest: Hash algorithm instance.
-
-    Returns:
-        bytes: Calculated signature.
+    :param rsakey: RSA private key used to sign the message.
+    :param message: Payload to sign.
+    :param digest: Hash algorithm instance.
+    :return: The calculated signature as bytes.
     """
     padding = _asymmetric.padding.PKCS1v15()
     signature = rsakey.sign(message, padding, digest)
@@ -39,14 +32,11 @@ def key_sign(rsakey, message, digest):
 def key_verify(rsakey, signature, message, digest):
     """Verify a PKCS#1 v1.5 signature using an RSA key.
 
-    Args:
-        rsakey: RSA key (private or public) used for verification.
-        signature: Signature bytes to check.
-        message: Original message bytes that were signed.
-        digest: Hash algorithm instance.
-
-    Returns:
-        bool: ``True`` when the signature is valid, otherwise ``False``.
+    :param rsakey: RSA key (private or public) used for verification.
+    :param signature: Signature bytes to check.
+    :param message: Original message bytes that were signed.
+    :param digest: Hash algorithm instance.
+    :return: ``True`` when the signature is valid, otherwise ``False``.
     """
     padding = _asymmetric.padding.PKCS1v15()
     if isinstance(rsakey, _asymmetric.rsa.RSAPrivateKey):

--- a/src/saml2/cryptography/pki.py
+++ b/src/saml2/cryptography/pki.py
@@ -14,11 +14,8 @@ DEFAULT_CERT_TYPE = "pem"
 def load_pem_x509_certificate(data):
     """Load an X.509 certificate from PEM encoded data.
 
-    Args:
-        data: PEM encoded certificate bytes.
-
-    Returns:
-        cryptography.x509.Certificate: Loaded certificate.
+    :param data: PEM encoded certificate bytes.
+    :return: Loaded certificate.
     """
     return _x509.load_pem_x509_certificate(data)
 
@@ -26,11 +23,8 @@ def load_pem_x509_certificate(data):
 def load_der_x509_certificate(data):
     """Load an X.509 certificate from DER encoded data.
 
-    Args:
-        data: DER encoded certificate bytes.
-
-    Returns:
-        cryptography.x509.Certificate: Loaded certificate.
+    :param data: DER encoded certificate bytes.
+    :return: Loaded certificate.
     """
     return _x509.load_der_x509_certificate(data)
 
@@ -38,12 +32,9 @@ def load_der_x509_certificate(data):
 def load_x509_certificate(data, cert_type="pem"):
     """Load an X.509 certificate in either PEM or DER format.
 
-    Args:
-        data: Certificate bytes.
-        cert_type: Encoding type, ``"pem"`` or ``"der"``.
-
-    Returns:
-        cryptography.x509.Certificate: Loaded certificate object.
+    :param data: Certificate bytes.
+    :param cert_type: Encoding type, ``"pem"`` or ``"der"``.
+    :return: Loaded certificate object.
     """
     cert_reader = _x509_loaders.get(cert_type)
 
@@ -63,11 +54,8 @@ def load_x509_certificate(data, cert_type="pem"):
 def get_public_bytes_from_cert(cert):
     """Return the certificate in PEM encoded textual form.
 
-    Args:
-        cert: Certificate to serialise.
-
-    Returns:
-        str: PEM encoded certificate string.
+    :param cert: Certificate to serialise.
+    :return: PEM encoded certificate string.
     """
     data = cert.public_bytes(_cryptography_encoding.PEM).decode()
     return data

--- a/src/saml2/cryptography/symmetric.py
+++ b/src/saml2/cryptography/symmetric.py
@@ -25,8 +25,7 @@ class Fernet:
     def generate_key():
         """Return a new encryption key.
 
-        Returns:
-            bytes: Key suitable for Fernet encryption/decryption.
+        :return: Key suitable for Fernet encryption/decryption.
         """
         key = _fernet.Fernet.generate_key()
         return key
@@ -34,8 +33,7 @@ class Fernet:
     def __init__(self, key=None):
         """Initialise the cipher with an optional pre-generated key.
 
-        Args:
-            key: Optional base64-encoded key material.
+        :param key: Optional base64-encoded key material.
         """
         if key:
             fernet_key_error = SymmetricCryptographyError("Fernet key must be 32 url-safe base64-encoded bytes.")
@@ -54,13 +52,10 @@ class Fernet:
     def encrypt(self, plaintext, *args, **kwargs):
         """Encrypt the given plaintext.
 
-        Args:
-            plaintext: Bytes representing the message to encrypt.
-            *args: Deprecated positional arguments.
-            **kwargs: Deprecated keyword arguments.
-
-        Returns:
-            bytes: Encrypted ciphertext.
+        :param plaintext: Bytes representing the message to encrypt.
+        :param args: Deprecated positional arguments.
+        :param kwargs: Deprecated keyword arguments.
+        :return: Encrypted ciphertext.
         """
         if args or kwargs:
             _deprecation_msg = (
@@ -78,13 +73,10 @@ class Fernet:
     def decrypt(self, ciphertext, *args, **kwargs):
         """Decrypt the given ciphertext.
 
-        Args:
-            ciphertext: Bytes representing the encrypted payload.
-            *args: Deprecated positional arguments.
-            **kwargs: Deprecated keyword arguments.
-
-        Returns:
-            bytes: Decrypted plaintext.
+        :param ciphertext: Bytes representing the encrypted payload.
+        :param args: Deprecated positional arguments.
+        :param kwargs: Deprecated keyword arguments.
+        :return: Decrypted plaintext.
         """
         if args or kwargs:
             _deprecation_msg = (
@@ -139,8 +131,7 @@ class AESCipher:
     def __init__(self, key):
         """Initialise the legacy AES cipher helper.
 
-        Args:
-            key: Raw encryption key bytes.
+        :param key: Raw encryption key bytes.
         """
         self.__class__._deprecation_notice()
         self.key = key
@@ -148,11 +139,9 @@ class AESCipher:
     def build_cipher(self, alg="aes_128_cbc"):
         """Construct a cryptography cipher for the requested algorithm.
 
-        Args:
-            alg: Cipher algorithm descriptor, e.g. ``"aes_128_cbc"``.
-
-        Returns:
-            tuple[Cipher, bytes]: Cipher instance and random IV.
+        :param alg: Cipher algorithm descriptor, e.g. ``"aes_128_cbc"``.
+        :return: A ``(cipher, iv)`` tuple containing the cipher instance and
+            random IV.
         """
         self.__class__._deprecation_notice()
         typ, bits, cmode = alg.lower().split("_")
@@ -180,15 +169,12 @@ class AESCipher:
     def encrypt(self, msg, alg="aes_128_cbc", padding="PKCS#7", b64enc=True, block_size=AES_BLOCK_SIZE):
         """Encrypt a message using the legacy AES helper.
 
-        Args:
-            msg: Plaintext message to encrypt.
-            alg: Cipher algorithm descriptor.
-            padding: Padding strategy name (``"PKCS#7"`` or ``"PKCS#5"``).
-            b64enc: Whether the result should be base64 encoded.
-            block_size: Block size to use with PKCS#7 padding.
-
-        Returns:
-            bytes: Encrypted (optionally base64 encoded) message.
+        :param msg: Plaintext message to encrypt.
+        :param alg: Cipher algorithm descriptor.
+        :param padding: Padding strategy name (``"PKCS#7"`` or ``"PKCS#5"``).
+        :param b64enc: Whether the result should be base64 encoded.
+        :param block_size: Block size to use with PKCS#7 padding.
+        :return: Encrypted (optionally base64 encoded) message.
         """
         self.__class__._deprecation_notice()
         if padding == "PKCS#7":
@@ -217,14 +203,11 @@ class AESCipher:
     def decrypt(self, msg, alg="aes_128_cbc", padding="PKCS#7", b64dec=True):
         """Decrypt a message using the legacy AES helper.
 
-        Args:
-            msg: Message to decrypt (base64 encoded by default).
-            alg: Cipher algorithm descriptor.
-            padding: Padding strategy name.
-            b64dec: Whether to base64 decode the input before decryption.
-
-        Returns:
-            bytes: Decrypted plaintext.
+        :param msg: Message to decrypt (base64 encoded by default).
+        :param alg: Cipher algorithm descriptor.
+        :param padding: Padding strategy name.
+        :param b64dec: Whether to base64 decode the input before decryption.
+        :return: Decrypted plaintext.
         """
         self.__class__._deprecation_notice()
         data = _base64.b64decode(msg) if b64dec else msg

--- a/src/saml2/discovery.py
+++ b/src/saml2/discovery.py
@@ -30,11 +30,10 @@ class DiscoveryServer(Entity):
     def __init__(self, config=None, config_file=""):
         """Initialise the discovery server with the given configuration.
 
-        Args:
-            config (dict | saml2.config.Config | None): Optional configuration
-                object used to configure the parent :class:`Entity`.
-            config_file (str): Path to a configuration file that should be
-                loaded when ``config`` is not supplied.
+        :param config: Optional configuration object used to configure the
+            parent :class:`Entity`.
+        :param config_file: Path to a configuration file that should be loaded
+            when ``config`` is not supplied.
         """
 
         if config or config_file:
@@ -43,23 +42,17 @@ class DiscoveryServer(Entity):
     def parse_discovery_service_request(self, url="", query=""):
         """Parse and validate an incoming discovery service request.
 
-        Args:
-            url (str): Full discovery service request URL including the query
-                string.
-            query (str): Raw query component when ``url`` is not already
-                provided.
-
-        Returns:
-            dict: Normalised mapping of discovery service request parameters
+        :param url: Full discovery service request URL including the query
+            string.
+        :param query: Raw query component when ``url`` is not already provided.
+        :return: Normalised mapping of discovery service request parameters
             with single string values.
-
-        Raises:
-            Exception: If a parameter contains duplicate values or violates the
-                discovery service semantics.
-            VerificationError: If the mandatory ``return`` parameter is
-                missing.
-            ValueError: If the ``isPassive`` flag is not ``"true"`` or
-                ``"false"``.
+        :raises Exception: If a parameter contains duplicate values or violates
+            the discovery service semantics.
+        :raises VerificationError: If the mandatory ``return`` parameter is
+            missing.
+        :raises ValueError: If the ``isPassive`` flag is not ``"true"`` or
+            ``"false"``.
         """
 
         if url:
@@ -112,18 +105,15 @@ class DiscoveryServer(Entity):
     def create_discovery_service_response(return_url=None, returnIDParam="entityID", entity_id=None, **kwargs):
         """Construct the redirect response for a Discovery Service request.
 
-        Args:
-            return_url (str | None): Endpoint supplied in the discovery request
-                that the user should be redirected back to.
-            returnIDParam (str): Query-string parameter name that the Service
-                Provider expects for the chosen IdP identifier.
-            entity_id (str | None): The identifier of the selected IdP to
-                append to the return URL when available.
-            **kwargs: Additional parameters that may contain ``return`` when
-                ``return_url`` is omitted.
-
-        Returns:
-            str: The redirect URL that should be returned to the user agent.
+        :param return_url: Endpoint supplied in the discovery request that the
+            user should be redirected back to.
+        :param returnIDParam: Query-string parameter name that the Service
+            Provider expects for the chosen IdP identifier.
+        :param entity_id: The identifier of the selected IdP to append to the
+            return URL when available.
+        :param kwargs: Additional parameters that may contain ``return`` when
+            ``return_url`` is omitted.
+        :return: The redirect URL that should be returned to the user agent.
         """
 
         if return_url is None:
@@ -143,11 +133,8 @@ class DiscoveryServer(Entity):
     def verify_sp_in_metadata(self, entity_id):
         """Check whether the Service Provider exists in the metadata store.
 
-        Args:
-            entity_id (str): EntityID of the Service Provider being validated.
-
-        Returns:
-            bool: ``True`` when discovery response endpoints are published in
+        :param entity_id: EntityID of the Service Provider being validated.
+        :return: ``True`` when discovery response endpoints are published in
             metadata, otherwise ``False``.
         """
 
@@ -161,14 +148,11 @@ class DiscoveryServer(Entity):
     def verify_return(self, entity_id, return_url):
         """Verify that the return URL is allowed for the Service Provider.
 
-        Args:
-            entity_id (str): EntityID of the Service Provider that issued the
-                discovery request.
-            return_url (str): URL that the Service Provider requested the user
-                should be redirected to.
-
-        Returns:
-            bool: ``True`` if the URL fails to match one of the discovery
+        :param entity_id: EntityID of the Service Provider that issued the
+            discovery request.
+        :param return_url: URL that the Service Provider requested the user
+            should be redirected to.
+        :return: ``True`` if the URL fails to match one of the discovery
             response locations published in metadata, otherwise ``False``.
         """
 

--- a/src/saml2/ecp.py
+++ b/src/saml2/ecp.py
@@ -34,12 +34,9 @@ logger = logging.getLogger(__name__)
 def ecp_capable(headers):
     """Determine if an HTTP request advertises ECP support.
 
-    Args:
-        headers (dict): Mapping of HTTP header names to values as provided by
-            the client.
-
-    Returns:
-        bool: ``True`` if the request accepts PAOS responses and identifies the
+    :param headers: Mapping of HTTP header names to values as provided by the
+        client.
+    :return: ``True`` if the request accepts PAOS responses and identifies the
         ECP service, otherwise ``False``.
     """
 
@@ -55,21 +52,16 @@ def ecp_capable(headers):
 def ecp_auth_request(cls, entityid=None, relay_state="", sign=None, sign_alg=None, digest_alg=None):
     """Create an ECP authentication request SOAP envelope.
 
-    Args:
-        cls: The service implementation building the request, typically a
-            :class:`saml2.client.Saml2Client` or compatible helper.
-        entityid (str | None): EntityID of the IdP that should receive the
-            request. ``None`` results in metadata-driven discovery.
-        relay_state (str): Opaque state returned to the caller after
-            successful login.
-        sign (bool | None): Controls whether the request is cryptographically
-            signed.
-        sign_alg (str | None): XML signature algorithm URI.
-        digest_alg (str | None): XML signature digest algorithm URI.
-
-    Returns:
-        tuple[str, str]: The generated request ID and the serialized SOAP
-        envelope as a string.
+    :param cls: The service implementation building the request, typically a
+        :class:`saml2.client.Saml2Client` or compatible helper.
+    :param entityid: EntityID of the IdP that should receive the request.
+        ``None`` results in metadata-driven discovery.
+    :param relay_state: Opaque state returned to the caller after successful
+        login.
+    :param sign: Controls whether the request is cryptographically signed.
+    :param sign_alg: XML signature algorithm URI.
+    :param digest_alg: XML signature digest algorithm URI.
+    :return: A tuple ``(request_id, soap_envelope)``.
     """
 
     eelist = []
@@ -155,16 +147,12 @@ def ecp_auth_request(cls, entityid=None, relay_state="", sign=None, sign_alg=Non
 def handle_ecp_authn_response(cls, soap_message, outstanding=None):
     """Parse an IdP authentication response delivered via the ECP channel.
 
-    Args:
-        cls: Service object responsible for processing the ECP message.
-        soap_message (str): Serialized SOAP envelope received from the IdP.
-        outstanding (dict | None): Outstanding request mapping used to validate
-            the response.
-
-    Returns:
-        tuple[saml2.response.AuthnResponse, saml2.profile.ecp.RelayState | None]:
-        Parsed authentication response together with the optional relay state
-        element.
+    :param cls: Service object responsible for processing the ECP message.
+    :param soap_message: Serialized SOAP envelope received from the IdP.
+    :param outstanding: Outstanding request mapping used to validate the
+        response.
+    :return: Parsed authentication response together with the optional relay
+        state element.
     """
 
     rdict = soap.class_instances_from_soap_enveloped_saml_thingies(soap_message, [paos, ecp, samlp])
@@ -186,14 +174,10 @@ def handle_ecp_authn_response(cls, soap_message, outstanding=None):
 def ecp_response(target_url, response):
     """Wrap an authentication response in an ECP SOAP envelope.
 
-    Args:
-        target_url (str): Assertion Consumer Service URL the client should
-            forward the response to.
-        response (saml2.response.AuthnResponse | samlp.Response): Parsed
-            response object to embed in the SOAP body.
-
-    Returns:
-        str: Serialized SOAP envelope ready to be sent to the client.
+    :param target_url: Assertion Consumer Service URL the client should forward
+        the response to.
+    :param response: Parsed response object to embed in the SOAP body.
+    :return: Serialized SOAP envelope ready to be sent to the client.
     """
 
     ecp_response = ecp.Response(assertion_consumer_service_url=target_url)
@@ -214,11 +198,10 @@ class ECPServer(Server):
     def __init__(self, config_file="", config=None, cache=None):
         """Create a new ECP-capable IdP server instance.
 
-        Args:
-            config_file (str): Path to the IdP configuration file.
-            config (dict | saml2.config.Config | None): In-memory configuration
-                object overriding ``config_file`` when provided.
-            cache: Optional cache backend supplied to :class:`Server`.
+        :param config_file: Path to the IdP configuration file.
+        :param config: In-memory configuration object overriding
+            ``config_file`` when provided.
+        :param cache: Optional cache backend supplied to :class:`Server`.
         """
 
         Server.__init__(self, config_file, config, cache)

--- a/src/saml2/eptid.py
+++ b/src/saml2/eptid.py
@@ -18,8 +18,7 @@ class Eptid:
     def __init__(self, secret):
         """Initialise the identifier store.
 
-        Args:
-            secret: Shared secret used when hashing identifiers.
+        :param secret: Shared secret used when hashing identifiers.
         """
         self._db = {}
         self.secret = secret
@@ -27,13 +26,10 @@ class Eptid:
     def make(self, idp, sp, args):
         """Produce an eduPersonTargetedID value.
 
-        Args:
-            idp: Entity identifier of the identity provider.
-            sp: Entity identifier of the service provider.
-            args: Tuple of stable identifiers for the subject.
-
-        Returns:
-            str: A ``!`` delimited targeted identifier.
+        :param idp: Entity identifier of the identity provider.
+        :param sp: Entity identifier of the service provider.
+        :param args: Tuple of stable identifiers for the subject.
+        :return: A ``!`` delimited targeted identifier.
         """
         md5 = hashlib.md5()
         for arg in args:
@@ -55,11 +51,9 @@ class Eptid:
     def __getitem__(self, key):
         """Retrieve a stored targeted identifier.
 
-        Args:
-            key: Key derived from the service provider and subject identifier.
-
-        Returns:
-            str: Persisted targeted identifier.
+        :param key: Key derived from the service provider and subject
+            identifier.
+        :return: Persisted targeted identifier.
         """
         if isinstance(key, bytes):
             key = key.decode("utf-8")
@@ -68,9 +62,8 @@ class Eptid:
     def __setitem__(self, key, value):
         """Store a targeted identifier in the internal mapping.
 
-        Args:
-            key: Dictionary key derived from the subject identifier.
-            value: Targeted identifier to persist.
+        :param key: Dictionary key derived from the subject identifier.
+        :param value: Targeted identifier to persist.
         """
         if isinstance(key, bytes):
             key = key.decode("utf-8")
@@ -79,13 +72,10 @@ class Eptid:
     def get(self, idp, sp, *args):
         """Return a deterministic targeted identifier.
 
-        Args:
-            idp: Entity identifier for the issuing identity provider.
-            sp: Entity identifier for the relying service provider.
-            *args: Stable subject identifiers such as internal IDs.
-
-        Returns:
-            str: Cached or newly generated targeted identifier.
+        :param idp: Entity identifier for the issuing identity provider.
+        :param sp: Entity identifier for the relying service provider.
+        :param args: Stable subject identifiers such as internal IDs.
+        :return: Cached or newly generated targeted identifier.
         """
         # key is a combination of sp_entity_id and object id
         key = ("__".join([sp, args[0]])).encode("utf-8")
@@ -107,9 +97,8 @@ class EptidShelve(Eptid):
     def __init__(self, secret, filename):
         """Initialise a shelve database for persistent identifiers.
 
-        Args:
-            secret: Shared secret used for deterministic hashing.
-            filename: Base file name for the shelve database.
+        :param secret: Shared secret used for deterministic hashing.
+        :param filename: Base file name for the shelve database.
         """
         Eptid.__init__(self, secret)
         if filename.endswith(".db"):

--- a/src/saml2/extension/mdattr.py
+++ b/src/saml2/extension/mdattr.py
@@ -37,12 +37,11 @@ class EntityAttributesType_(SamlBase):
     ):
         """Initialise the entity attributes collection.
 
-        Args:
-            attribute: Sequence of :class:`saml.Attribute` instances.
-            assertion: Sequence of :class:`saml.Assertion` instances.
-            text: Raw text payload.
-            extension_elements: Additional XML child elements.
-            extension_attributes: Additional XML attributes.
+        :param attribute: Sequence of :class:`saml.Attribute` instances.
+        :param assertion: Sequence of :class:`saml.Assertion` instances.
+        :param text: Raw text payload.
+        :param extension_elements: Additional XML child elements.
+        :param extension_attributes: Additional XML attributes.
         """
         SamlBase.__init__(
             self,

--- a/src/saml2/extension/shibmd.py
+++ b/src/saml2/extension/shibmd.py
@@ -27,12 +27,11 @@ class Scope(SamlBase):
     def __init__(self, regexp="false", text=None, extension_elements=None, extension_attributes=None):
         """Initialise a metadata scope element.
 
-        Args:
-            regexp: Flag indicating whether the scope is interpreted as a
-                regular expression.
-            text: Raw text payload for the element.
-            extension_elements: Additional XML child elements.
-            extension_attributes: Additional XML attributes.
+        :param regexp: Flag indicating whether the scope is interpreted as a
+            regular expression.
+        :param text: Raw text payload for the element.
+        :param extension_elements: Additional XML child elements.
+        :param extension_attributes: Additional XML attributes.
         """
         SamlBase.__init__(
             self, text=text, extension_elements=extension_elements, extension_attributes=extension_attributes
@@ -62,12 +61,12 @@ class KeyAuthority(SamlBase):
     def __init__(self, key_info=None, verify_depth="1", text=None, extension_elements=None, extension_attributes=None):
         """Initialise a key authority description.
 
-        Args:
-            key_info: Sequence of :class:`~saml2.xmldsig.KeyInfo` elements.
-            verify_depth: Verification depth allowed when chaining authorities.
-            text: Raw text payload.
-            extension_elements: Additional XML child elements.
-            extension_attributes: Additional XML attributes.
+        :param key_info: Sequence of :class:`~saml2.xmldsig.KeyInfo` elements.
+        :param verify_depth: Verification depth allowed when chaining
+            authorities.
+        :param text: Raw text payload.
+        :param extension_elements: Additional XML child elements.
+        :param extension_attributes: Additional XML attributes.
         """
         SamlBase.__init__(
             self, text=text, extension_elements=extension_elements, extension_attributes=extension_attributes

--- a/src/saml2/ident.py
+++ b/src/saml2/ident.py
@@ -28,11 +28,8 @@ class Unknown(SAMLError):
 def code(item):
     """Serialise a :class:`~saml2.saml.NameID` into a lookup string.
 
-    Args:
-        item: NameID instance to encode.
-
-    Returns:
-        str: Comma separated list of indexed attributes suitable for storage.
+    :param item: NameID instance to encode.
+    :return: Comma separated list of indexed attributes suitable for storage.
     """
     _res = []
     i = 0
@@ -47,11 +44,8 @@ def code(item):
 def code_binary(item):
     """Return a binary representation of :func:`code` output.
 
-    Args:
-        item: NameID instance to encode.
-
-    Returns:
-        bytes: UTF-8 encoded representation of :func:`code`.
+    :param item: NameID instance to encode.
+    :return: UTF-8 encoded representation of :func:`code`.
     """
     code_str = code(item)
     if isinstance(code_str, str):
@@ -62,11 +56,8 @@ def code_binary(item):
 def decode(txt):
     """Parse a string created by :func:`code` back into a NameID instance.
 
-    Args:
-        txt: Encoded representation produced by :func:`code`.
-
-    Returns:
-        saml2.saml.NameID: Decoded NameID value.
+    :param txt: Encoded representation produced by :func:`code`.
+    :return: Decoded NameID value.
     """
     _nid = NameID()
     for part in txt.split(","):
@@ -85,10 +76,9 @@ class IdentDB:
     def __init__(self, db, domain="", name_qualifier=""):
         """Initialise the identifier database.
 
-        Args:
-            db: ``shelve`` path or dictionary-like storage backend.
-            domain: Domain used when minting email address identifiers.
-            name_qualifier: Default name qualifier to apply.
+        :param db: ``shelve`` path or dictionary-like storage backend.
+        :param domain: Domain used when minting email address identifiers.
+        :param name_qualifier: Default name qualifier to apply.
         """
         if isinstance(db, str):
             self.db = shelve.open(db, protocol=2)
@@ -123,9 +113,8 @@ class IdentDB:
     def store(self, ident, name_id):
         """Persist the association between a user identifier and NameID.
 
-        Args:
-            ident: Internal user identifier.
-            name_id: Issued NameID instance.
+        :param ident: Internal user identifier.
+        :param name_id: Issued NameID instance.
         """
         # One user may have more than one NameID defined
         try:
@@ -141,8 +130,7 @@ class IdentDB:
     def remove_remote(self, name_id):
         """Remove the mapping from a NameID back to the local identifier.
 
-        Args:
-            name_id: NameID instance to remove.
+        :param name_id: NameID instance to remove.
         """
         _cn = code(name_id)
         _id = self.db[name_id.text]
@@ -158,8 +146,7 @@ class IdentDB:
     def remove_local(self, sid):
         """Remove all NameIDs associated with a local identifier.
 
-        Args:
-            sid: Local identifier whose NameIDs should be purged.
+        :param sid: Local identifier whose NameIDs should be purged.
         """
         if not isinstance(sid, bytes):
             sid = sid.encode("utf-8")
@@ -178,14 +165,11 @@ class IdentDB:
     def get_nameid(self, userid, nformat, sp_name_qualifier, name_qualifier):
         """Return an existing or newly issued NameID for a user.
 
-        Args:
-            userid: Internal user identifier.
-            nformat: Requested NameID format.
-            sp_name_qualifier: Service provider name qualifier.
-            name_qualifier: Issuer name qualifier.
-
-        Returns:
-            saml2.saml.NameID: Persistent NameID matching the request.
+        :param userid: Internal user identifier.
+        :param nformat: Requested NameID format.
+        :param sp_name_qualifier: Service provider name qualifier.
+        :param name_qualifier: Issuer name qualifier.
+        :return: Persistent NameID matching the request.
         """
         if nformat == NAMEID_FORMAT_PERSISTENT:
             nameid = self.match_local_id(userid, sp_name_qualifier, name_qualifier)
@@ -214,12 +198,9 @@ class IdentDB:
     def find_nameid(self, userid, **kwargs):
         """Return NameIDs that match the given attribute filters.
 
-        Args:
-            userid: Internal user identifier.
-            **kwargs: Attribute/value filters that each NameID must satisfy.
-
-        Returns:
-            list[saml2.saml.NameID]: Matching NameIDs.
+        :param userid: Internal user identifier.
+        :param kwargs: Attribute/value filters that each NameID must satisfy.
+        :return: Matching NameIDs.
         """
         res = []
         try:
@@ -306,11 +287,8 @@ class IdentDB:
     def find_local_id(self, name_id):
         """Return the internal identifier corresponding to a persistent NameID.
 
-        Args:
-            name_id: NameID instance issued previously by this IdP.
-
-        Returns:
-            str | None: Internal identifier or ``None`` if not found.
+        :param name_id: NameID instance issued previously by this IdP.
+        :return: Internal identifier or ``None`` if not found.
         """
 
         try:
@@ -323,13 +301,10 @@ class IdentDB:
     def match_local_id(self, userid, sp_name_qualifier, name_qualifier):
         """Find a non-transient NameID that matches the provided qualifiers.
 
-        Args:
-            userid: Internal user identifier.
-            sp_name_qualifier: Expected SP name qualifier.
-            name_qualifier: Expected issuer name qualifier.
-
-        Returns:
-            saml2.saml.NameID | None: Matching NameID or ``None`` if missing.
+        :param userid: Internal user identifier.
+        :param sp_name_qualifier: Expected SP name qualifier.
+        :param name_qualifier: Expected issuer name qualifier.
+        :return: Matching NameID or ``None`` if missing.
         """
         try:
             for val in self.db[userid].split(" "):
@@ -357,17 +332,11 @@ class IdentDB:
     def handle_name_id_mapping_request(self, name_id, name_id_policy):
         """Handle a NameID mapping request from a service provider.
 
-        Args:
-            name_id: The NameID that identifies the principal.
-            name_id_policy: Policy describing the desired NameID format.
-
-        Returns:
-            saml2.saml.NameID: Existing or newly created NameID that matches the
-            policy.
-
-        Raises:
-            Unknown: When the supplied NameID cannot be resolved.
-            PolicyError: When the policy forbids creating new identifiers.
+        :param name_id: The NameID that identifies the principal.
+        :param name_id_policy: Policy describing the desired NameID format.
+        :return: Existing or newly created NameID that matches the policy.
+        :raises Unknown: When the supplied NameID cannot be resolved.
+        :raises PolicyError: When the policy forbids creating new identifiers.
         """
         _id = self.find_local_id(name_id)
         if not _id:
@@ -389,14 +358,12 @@ class IdentDB:
     def handle_manage_name_id_request(self, name_id, new_id=None, new_encrypted_id="", terminate=""):
         """Process a ManageNameID request that updates SP-provided identifiers.
 
-        Args:
-            name_id: NameID instance to update.
-            new_id: Optional :class:`~saml2.samlp.NewID` value.
-            new_encrypted_id: Optional encrypted ID payload (not yet supported).
-            terminate: Optional :class:`~saml2.samlp.Terminate` request.
-
-        Returns:
-            saml2.saml.NameID: Updated NameID instance.
+        :param name_id: NameID instance to update.
+        :param new_id: Optional :class:`~saml2.samlp.NewID` value.
+        :param new_encrypted_id: Optional encrypted ID payload (not yet
+            supported).
+        :param terminate: Optional :class:`~saml2.samlp.Terminate` request.
+        :return: Updated NameID instance.
         """
         _id = self.find_local_id(name_id)
 

--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -65,13 +65,10 @@ bXMLNSXS = b' xmlns:xs="http://www.w3.org/2001/XMLSchema"'
 def metadata_tostring_fix(desc, nspair, xmlstring=""):
     """Render metadata to XML while ensuring XML schema namespaces exist.
 
-    Args:
-        desc: Metadata object to serialise.
-        nspair: Namespace prefix mapping passed to ``to_string``.
-        xmlstring: Optional pre-rendered XML string to adjust.
-
-    Returns:
-        str | bytes: XML representation with the necessary schema namespace.
+    :param desc: Metadata object to serialise.
+    :param nspair: Namespace prefix mapping passed to ``to_string``.
+    :param xmlstring: Optional pre-rendered XML string to adjust.
+    :return: XML representation with the necessary schema namespace.
     """
     if not xmlstring:
         xmlstring = desc.to_string(nspair)
@@ -100,20 +97,18 @@ def create_metadata_string(
 ):
     """Create an entity or entities descriptor for the provided configuration.
 
-    Args:
-        configfile: Path to the configuration module when ``config`` is ``None``.
-        config: Optional pre-loaded configuration object.
-        valid: Validity duration in hours for generated metadata.
-        cert: Optional signing certificate override.
-        keyfile: Optional signing key override.
-        mid: Optional entity descriptor ID for the metadata container.
-        name: Optional name for an entities descriptor wrapper.
-        sign: Flag indicating whether to sign the metadata output.
-        sign_alg: Signature algorithm override.
-        digest_alg: Digest algorithm override.
-
-    Returns:
-        str | bytes: Serialised metadata document ready for distribution.
+    :param configfile: Path to the configuration module when ``config`` is
+        ``None``.
+    :param config: Optional pre-loaded configuration object.
+    :param valid: Validity duration in hours for generated metadata.
+    :param cert: Optional signing certificate override.
+    :param keyfile: Optional signing key override.
+    :param mid: Optional entity descriptor ID for the metadata container.
+    :param name: Optional name for an entities descriptor wrapper.
+    :param sign: Flag indicating whether to sign the metadata output.
+    :param sign_alg: Signature algorithm override.
+    :param digest_alg: Digest algorithm override.
+    :return: Serialised metadata document ready for distribution.
     """
     valid_for = 0
     nspair = {"xs": "http://www.w3.org/2001/XMLSchema"}
@@ -560,13 +555,10 @@ def do_spsso_descriptor(conf, cert=None, enc_cert=None):
 def do_idpsso_descriptor(conf, cert=None, enc_cert=None):
     """Build an :class:`~saml2.md.IDPSSODescriptor` from configuration data.
 
-    Args:
-        conf: Loaded configuration instance.
-        cert: Signing certificate contents or path.
-        enc_cert: Encryption certificate contents or path.
-
-    Returns:
-        saml2.md.IDPSSODescriptor: Metadata describing the IdP SSO service.
+    :param conf: Loaded configuration instance.
+    :param cert: Signing certificate contents or path.
+    :param enc_cert: Encryption certificate contents or path.
+    :return: Metadata describing the IdP SSO service.
     """
     idpsso = md.IDPSSODescriptor()
     idpsso.protocol_support_enumeration = samlp.NAMESPACE
@@ -739,12 +731,9 @@ def _add_attr_to_entity_attributes(extensions, attribute):
 def entity_descriptor(confd):
     """Build an :class:`~saml2.md.EntityDescriptor` from configuration.
 
-    Args:
-        confd: Loaded configuration instance whose ``context`` determines which
-            services to expose.
-
-    Returns:
-        saml2.md.EntityDescriptor: Metadata for the configured entity.
+    :param confd: Loaded configuration instance whose ``context`` determines
+        which services to expose.
+    :return: Metadata for the configured entity.
     """
     mycert = None
     enc_cert = None

--- a/src/saml2/profile/ecp.py
+++ b/src/saml2/profile/ecp.py
@@ -47,19 +47,19 @@ class RequestType_(SamlBase):
     ):
         """Populate the ECP request envelope metadata.
 
-        Args:
-            issuer: Optional :class:`saml.Issuer` describing the IdP.
-            idp_list: Optional :class:`samlp.IDPList` offering IdP candidates.
-            must_understand: SOAP ``mustUnderstand`` flag.
-            actor: SOAP ``actor`` identifier.
-            provider_name: Display name of the service provider.
-            is_passive: Flag indicating whether passive authentication is
-                requested.
-            text: Raw text payload for the element.
-            extension_elements: Extra XML child elements that are not part of
-                the schema.
-            extension_attributes: Additional XML attributes that extend the
-                schema.
+        :param issuer: Optional :class:`saml.Issuer` describing the IdP.
+        :param idp_list: Optional :class:`samlp.IDPList` offering IdP
+            candidates.
+        :param must_understand: SOAP ``mustUnderstand`` flag.
+        :param actor: SOAP ``actor`` identifier.
+        :param provider_name: Display name of the service provider.
+        :param is_passive: Flag indicating whether passive authentication is
+            requested.
+        :param text: Raw text payload for the element.
+        :param extension_elements: Extra XML child elements that are not part
+            of the schema.
+        :param extension_attributes: Additional XML attributes that extend the
+            schema.
         """
         SamlBase.__init__(
             self,
@@ -78,11 +78,8 @@ class RequestType_(SamlBase):
 def request_type__from_string(xml_string):
     """Parse an ECP ``RequestType`` element from XML.
 
-    Args:
-        xml_string: XML representation of the request.
-
-    Returns:
-        RequestType_: Parsed request wrapper.
+    :param xml_string: XML representation of the request.
+    :return: Parsed request wrapper.
     """
     return saml2.create_class_from_xml_string(RequestType_, xml_string)
 
@@ -111,13 +108,12 @@ class ResponseType_(SamlBase):
     ):
         """Initialise the ECP response header wrapper.
 
-        Args:
-            must_understand: SOAP ``mustUnderstand`` flag.
-            actor: SOAP ``actor`` identifier.
-            assertion_consumer_service_url: ACS endpoint selected by the IdP.
-            text: Raw text payload.
-            extension_elements: Additional XML child elements.
-            extension_attributes: Additional XML attributes.
+        :param must_understand: SOAP ``mustUnderstand`` flag.
+        :param actor: SOAP ``actor`` identifier.
+        :param assertion_consumer_service_url: ACS endpoint selected by the IdP.
+        :param text: Raw text payload.
+        :param extension_elements: Additional XML child elements.
+        :param extension_attributes: Additional XML attributes.
         """
         SamlBase.__init__(
             self,
@@ -158,12 +154,11 @@ class RelayStateType_(SamlBase):
     ):
         """Configure a SOAP relay state wrapper for ECP.
 
-        Args:
-            must_understand: SOAP ``mustUnderstand`` flag.
-            actor: SOAP ``actor`` identifier.
-            text: Relay state payload.
-            extension_elements: XML children extending the element.
-            extension_attributes: XML attributes extending the element.
+        :param must_understand: SOAP ``mustUnderstand`` flag.
+        :param actor: SOAP ``actor`` identifier.
+        :param text: Relay state payload.
+        :param extension_elements: XML children extending the element.
+        :param extension_attributes: XML attributes extending the element.
         """
         SamlBase.__init__(
             self,

--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -25,13 +25,12 @@ class Request:
     def __init__(self, sec_context, receiver_addrs, attribute_converters=None, timeslack=0):
         """Initialise the request wrapper.
 
-        Args:
-            sec_context: Security context used for signature validation.
-            receiver_addrs: Iterable of endpoints on which this process expects
-                to receive requests.
-            attribute_converters: Optional converters for attribute names.
-            timeslack: Allowed clock skew in seconds when validating issue
-                instants.
+        :param sec_context: Security context used for signature validation.
+        :param receiver_addrs: Iterable of endpoints on which this process
+            expects to receive requests.
+        :param attribute_converters: Optional converters for attribute names.
+        :param timeslack: Allowed clock skew in seconds when validating issue
+            instants.
         """
         self.sec = sec_context
         self.receiver_addrs = receiver_addrs
@@ -65,24 +64,21 @@ class Request:
     ):
         """Parse a request and enforce signature requirements when configured.
 
-        Args:
-            xmldata: XML payload to parse.
-            binding: SAML binding used to deliver the request.
-            origdoc: Original base64-encoded request payload for Redirect
-                validation.
-            must: Flag indicating whether signatures are mandatory.
-            only_valid_cert: When ``True`` only currently valid certificates are
-                accepted.
-            relay_state: Optional relay state accompanying the request.
-            sigalg: Signature algorithm parameter from the HTTP-Redirect query.
-            signature: Signature parameter from the HTTP-Redirect query.
-
-        Returns:
-            Request: ``self`` for fluent usage.
-
-        Raises:
-            IncorrectlySigned: If the request fails mandatory signature checks.
-            NotValid: If schema validation fails.
+        :param xmldata: XML payload to parse.
+        :param binding: SAML binding used to deliver the request.
+        :param origdoc: Original base64-encoded request payload for Redirect
+            validation.
+        :param must: Flag indicating whether signatures are mandatory.
+        :param only_valid_cert: When ``True`` only currently valid certificates
+            are accepted.
+        :param relay_state: Optional relay state accompanying the request.
+        :param sigalg: Signature algorithm parameter from the HTTP-Redirect
+            query.
+        :param signature: Signature parameter from the HTTP-Redirect query.
+        :return: ``self`` for fluent usage.
+        :raises IncorrectlySigned: If the request fails mandatory signature
+            checks.
+        :raises NotValid: If schema validation fails.
         """
         # own copy
         self.xmlstr = xmldata[:]
@@ -144,12 +140,9 @@ class Request:
     def _do_redirect_sig_check(self, _saml_msg):
         """Validate an HTTP-Redirect signature against IdP metadata certificates.
 
-        Args:
-            _saml_msg: Mapping containing ``SAMLRequest``, ``Signature``,
-                ``SigAlg`` and optionally ``RelayState``.
-
-        Returns:
-            bool: ``True`` if any configured certificate validates the message.
+        :param _saml_msg: Mapping containing ``SAMLRequest``, ``Signature``,
+            ``SigAlg`` and optionally ``RelayState``.
+        :return: ``True`` if any configured certificate validates the message.
         """
         issuer = self.sender()
         certs = self.sec.metadata.certs(issuer, "any", "signing")
@@ -161,8 +154,7 @@ class Request:
     def issue_instant_ok(self):
         """Check that the request was issued at a reasonable time.
 
-        Returns:
-            bool: ``True`` if the issue instant is within the configured skew.
+        :return: ``True`` if the issue instant is within the configured skew.
         """
         upper = time_util.shift_time(time_util.time_in_a_while(days=1), self.timeslack).timetuple()
         lower = time_util.shift_time(time_util.time_a_while_ago(days=1), -self.timeslack).timetuple()
@@ -174,12 +166,9 @@ class Request:
     def _verify(self):
         """Validate version, destination, and freshness constraints.
 
-        Returns:
-            bool: ``True`` if the request passes baseline checks.
-
-        Raises:
-            VersionMismatch: If the SAML version is unsupported.
-            OtherError: If the destination does not match a known endpoint.
+        :return: ``True`` if the request passes baseline checks.
+        :raises VersionMismatch: If the SAML version is unsupported.
+        :raises OtherError: If the destination does not match a known endpoint.
         """
         valid_version = "2.0"
         if self.message.version != valid_version:
@@ -228,8 +217,7 @@ class Request:
         The name identifier can be represented as ``BaseID``, ``NameID`` or an
         ``EncryptedID``.
 
-        Returns:
-            Optional[str]: Identifier if present, otherwise ``None``.
+        :return: Identifier if present, otherwise ``None``.
         """
 
         if "subject" in self.message.keys():

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -142,26 +142,20 @@ def valid_email(emailaddress, domains=GENERIC_DOMAINS):
 
 
 def decode_base64_and_inflate(string):
-    """Decode a deflated Base64-encoded string.
+    """Base64 decode and then inflate according to RFC1951.
 
-    Args:
-        string: Deflated and Base64 encoded payload as bytes or string.
-
-    Returns:
-        bytes: Decompressed payload.
+    :param string: A deflated and encoded string.
+    :return: The string after decoding and inflating.
     """
 
     return zlib.decompress(base64.b64decode(string), -15)
 
 
 def deflate_and_base64_encode(string_val):
-    """Deflate and Base64 encode a string.
+    """Deflate and then Base64 encode a string.
 
-    Args:
-        string_val: Text or bytes to encode.
-
-    Returns:
-        bytes: Deflated and encoded representation.
+    :param string_val: The string to deflate and encode.
+    :return: The deflated and encoded string.
     """
     if not isinstance(string_val, bytes):
         string_val = string_val.encode("utf-8")
@@ -169,14 +163,11 @@ def deflate_and_base64_encode(string_val):
 
 
 def rndstr(size=16, alphabet=""):
-    """Return a random string of ASCII letters and digits.
+    """Return a string of random ASCII characters or digits.
 
-    Args:
-        size: Length of the string to generate.
-        alphabet: Optional alphabet override. Defaults to letters and digits.
-
-    Returns:
-        str: Randomly generated string.
+    :param size: The length of the string.
+    :param alphabet: Optional alphabet override. Defaults to letters and digits.
+    :return: A random string.
     """
     rng = random.SystemRandom()
     if not alphabet:
@@ -185,15 +176,7 @@ def rndstr(size=16, alphabet=""):
 
 
 def rndbytes(size=16, alphabet=""):
-    """Return a random byte sequence using :func:`rndstr` under the hood.
-
-    Args:
-        size: Length of the byte string to generate.
-        alphabet: Optional alphabet override.
-
-    Returns:
-        bytes: Random bytes suitable for cryptographic identifiers.
-    """
+    """Return :func:`rndstr` output as a binary type."""
     x = rndstr(size, alphabet)
     if isinstance(x, str):
         return x.encode("utf-8")
@@ -201,10 +184,13 @@ def rndbytes(size=16, alphabet=""):
 
 
 def sid():
-    """Create a random session identifier that satisfies SAML 2.0 limits.
+    """Create a unique SID for each session.
 
-    Returns:
-        str: Identifier prefixed with ``"id-"`` suitable for XML IDs.
+    160-bits long so it fulfills the SAML2 requirements which state 128-160
+    bits.
+
+    :return: A random string prefixed with ``"id-"`` to make it compliant with
+        the NCName specification.
     """
     return f"id-{rndstr(17)}"
 

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -1696,11 +1696,8 @@ class AssertionType_(SamlBase):
 def assertion_type__from_string(xml_string):
     """Parse XML into an :class:`AssertionType_` instance.
 
-    Args:
-        xml_string: XML representation of an assertion type.
-
-    Returns:
-        AssertionType_: Parsed assertion type object.
+    :param xml_string: XML representation of an assertion type.
+    :return: Parsed assertion type object.
     """
 
     return saml2.create_class_from_xml_string(AssertionType_, xml_string)
@@ -1720,11 +1717,8 @@ class Assertion(AssertionType_):
 def assertion_from_string(xml_string):
     """Parse XML into an :class:`Assertion` instance.
 
-    Args:
-        xml_string: XML representation of an assertion.
-
-    Returns:
-        Assertion: Parsed assertion object.
+    :param xml_string: XML representation of an assertion.
+    :return: Parsed assertion object.
     """
 
     return saml2.create_class_from_xml_string(Assertion, xml_string)

--- a/src/saml2/samlp.py
+++ b/src/saml2/samlp.py
@@ -1288,11 +1288,8 @@ class AuthnRequestType_(RequestAbstractType_):
 def authn_request_type__from_string(xml_string):
     """Parse XML into an :class:`AuthnRequestType_` instance.
 
-    Args:
-        xml_string: XML representation of an authentication request type.
-
-    Returns:
-        AuthnRequestType_: Parsed object model.
+    :param xml_string: XML representation of an authentication request type.
+    :return: Parsed object model.
     """
 
     return saml2.create_class_from_xml_string(AuthnRequestType_, xml_string)
@@ -1312,11 +1309,8 @@ class AuthnRequest(AuthnRequestType_):
 def authn_request_from_string(xml_string):
     """Parse XML into an :class:`AuthnRequest` instance.
 
-    Args:
-        xml_string: XML representation of an authentication request.
-
-    Returns:
-        AuthnRequest: Parsed object model.
+    :param xml_string: XML representation of an authentication request.
+    :return: Parsed object model.
     """
 
     return saml2.create_class_from_xml_string(AuthnRequest, xml_string)
@@ -1614,11 +1608,8 @@ class Response(ResponseType_):
 def response_from_string(xml_string):
     """Parse XML into a :class:`Response` instance.
 
-    Args:
-        xml_string: XML representation of a SAML response.
-
-    Returns:
-        Response: Parsed response object.
+    :param xml_string: XML representation of a SAML response.
+    :return: Parsed response object.
     """
 
     return saml2.create_class_from_xml_string(Response, xml_string)

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -63,17 +63,12 @@ def _shelve_compat(name, *args, **kwargs):
     attempt the ``.db`` suffix to determine the database type, so the function
     retries without the suffix if necessary.
 
-    Args:
-        name: The base filename of the shelve database.
-        *args: Positional arguments forwarded to ``shelve.open``.
-        **kwargs: Keyword arguments forwarded to ``shelve.open``.
-
-    Returns:
-        shelve.DbfilenameShelf: An opened shelf instance.
-
-    Raises:
-        dbm.error: If the shelve database cannot be opened even after retrying
-            without the ``.db`` suffix.
+    :param name: The base filename of the shelve database.
+    :param args: Positional arguments forwarded to ``shelve.open``.
+    :param kwargs: Keyword arguments forwarded to ``shelve.open``.
+    :return: An opened shelf instance.
+    :raises dbm.error: If the shelve database cannot be opened even after
+        retrying without the ``.db`` suffix.
     """
 
     try:
@@ -101,16 +96,15 @@ class Server(Entity):
     ):
         """Initialise an IdP or AA server entity.
 
-        Args:
-            config_file: Path to a configuration file to load.
-            config: In-memory configuration dictionary that overrides
-                ``config_file`` when provided.
-            cache: Optional cache backend for session data.
-            stype: Entity type for the server, typically ``"idp"`` or
-                ``"aa"``.
-            symkey: Symmetric key used for encrypting data. A random key is
-                generated when not supplied.
-            msg_cb: Callback invoked for outgoing protocol messages.
+        :param config_file: Path to a configuration file to load.
+        :param config: In-memory configuration dictionary that overrides
+            ``config_file`` when provided.
+        :param cache: Optional cache backend for session data.
+        :param stype: Entity type for the server, typically ``"idp"`` or
+            ``"aa"``.
+        :param symkey: Symmetric key used for encrypting data. A random key is
+            generated when not supplied.
+        :param msg_cb: Callback invoked for outgoing protocol messages.
         """
 
         Entity.__init__(self, stype, config, config_file, msg_cb=msg_cb)
@@ -129,10 +123,8 @@ class Server(Entity):
     def getvalid_certificate_str(self):
         """Return the last successfully validated certificate string.
 
-        Returns:
-            str | None: PEM-formatted certificate last validated by the
-            security handler, or ``None`` when no certificate has been
-            processed yet.
+        :return: PEM-formatted certificate last validated by the security
+            handler, or ``None`` when no certificate has been processed yet.
         """
 
         if self.sec.cert_handler is not None:
@@ -142,8 +134,7 @@ class Server(Entity):
     def support_AssertionIDRequest(self):
         """Report support for AssertionIDRequest messages.
 
-        Returns:
-            bool: Always ``True`` since AssertionIDRequest is supported.
+        :return: Always ``True`` since AssertionIDRequest is supported.
         """
 
         return True
@@ -151,8 +142,7 @@ class Server(Entity):
     def support_AuthnQuery(self):
         """Report support for AuthnQuery messages.
 
-        Returns:
-            bool: Always ``True`` since AuthnQuery is supported.
+        :return: Always ``True`` since AuthnQuery is supported.
         """
 
         return True
@@ -160,12 +150,9 @@ class Server(Entity):
     def choose_session_storage(self):
         """Select the session storage backend for the IdP.
 
-        Returns:
-            SessionStorage: Storage implementation configured for the IdP.
-
-        Raises:
-            NotImplementedError: If the configured storage type is not
-                recognised.
+        :return: Storage implementation configured for the IdP.
+        :raises NotImplementedError: If the configured storage type is not
+            recognised.
         """
 
         _spec = self.config.getattr("session_storage", "idp")
@@ -186,11 +173,8 @@ class Server(Entity):
     def init_config(self, stype="idp"):
         """Finish configuring the server based on its entity type.
 
-        Args:
-            stype: Server type, typically ``"idp"`` or ``"aa"``.
-
-        Raises:
-            Exception: If the identity database cannot be opened.
+        :param stype: Server type, typically ``"idp"`` or ``"aa"``.
+        :raises Exception: If the identity database cannot be opened.
         """
         if stype == "aa":
             return
@@ -260,14 +244,10 @@ class Server(Entity):
     def wants(self, sp_entity_id, index=None):
         """Return the required and optional attributes for a service provider.
 
-        Args:
-            sp_entity_id: The entity ID of the service provider.
-            index: Optional attribute consumer service index. When ``None`` all
-                services are considered together.
-
-        Returns:
-            tuple[list[str], list[str]]: The required and optional attributes
-            as defined in metadata.
+        :param sp_entity_id: The entity ID of the service provider.
+        :param index: Optional attribute consumer service index. When ``None``
+            all services are considered together.
+        :return: The required and optional attributes as defined in metadata.
         """
         return self.metadata.attribute_requirement(sp_entity_id, index)
 

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -170,15 +170,10 @@ def signed(item):
 def get_xmlsec_binary(paths=None):
     """Locate the ``xmlsec1`` binary.
 
-    Args:
-        paths: Optional iterable of additional directories to search before
-            the system ``PATH``.
-
-    Returns:
-        str: Absolute path to the executable.
-
-    Raises:
-        SigverError: If the binary cannot be located.
+    :param paths: Optional iterable of additional directories to search before
+        the system ``PATH``.
+    :return: Absolute path to the executable.
+    :raises SigverError: If the binary cannot be located.
     """
     if os.name == "posix":
         bin_name = ["xmlsec1"]
@@ -212,13 +207,10 @@ def get_xmlsec_binary(paths=None):
 def _get_xmlsec_cryptobackend(path=None, search_paths=None, delete_tmpfiles=True):
     """Initialise a :class:`CryptoBackendXmlSec1` helper.
 
-    Args:
-        path: Explicit path to the xmlsec binary.
-        search_paths: Extra directories to search when ``path`` is ``None``.
-        delete_tmpfiles: Whether temporary files should be removed.
-
-    Returns:
-        CryptoBackendXmlSec1: Backend wrapper prepared for signing operations.
+    :param path: Explicit path to the xmlsec binary.
+    :param search_paths: Extra directories to search when ``path`` is ``None``.
+    :param delete_tmpfiles: Whether temporary files should be removed.
+    :return: Backend wrapper prepared for signing operations.
     """
     if path is None:
         path = get_xmlsec_binary(paths=search_paths)
@@ -324,15 +316,12 @@ def _instance(klass, ava, seccont, base64encode=False, elements_to_sign=None):
 def signed_instance_factory(instance, seccont, elements_to_sign=None):
     """Return a helper that signs the provided XML instance when invoked.
 
-    Args:
-        instance: XML object or serialised XML string to sign.
-        seccont: Security context capable of applying XML signatures.
-        elements_to_sign: Iterable of ``(node_name, node_id)`` tuples describing
-            the elements that should be signed.
-
-    Returns:
-        str | saml2.saml.Base: Signed XML serialisation or the original
-        ``instance`` when ``elements_to_sign`` is falsy.
+    :param instance: XML object or serialised XML string to sign.
+    :param seccont: Security context capable of applying XML signatures.
+    :param elements_to_sign: Iterable of ``(node_name, node_id)`` tuples
+        describing the elements that should be signed.
+    :return: Signed XML serialisation or the original ``instance`` when
+        ``elements_to_sign`` is falsy.
     """
     if not elements_to_sign:
         return instance
@@ -350,14 +339,11 @@ def signed_instance_factory(instance, seccont, elements_to_sign=None):
 def make_temp(content, suffix="", decode=True, delete_tmpfiles=True):
     """Create a temporary file for use with ``xmlsec`` operations.
 
-    Args:
-        content: Text or bytes that should be written to the file.
-        suffix: Optional filename suffix required by ``xmlsec``.
-        decode: ``True`` to base64 decode ``content`` before writing.
-        delete_tmpfiles: ``True`` to delete the file when closed.
-
-    Returns:
-        tempfile.NamedTemporaryFile: Handle for the created file.
+    :param content: Text or bytes that should be written to the file.
+    :param suffix: Optional filename suffix required by ``xmlsec``.
+    :param decode: ``True`` to base64 decode ``content`` before writing.
+    :param delete_tmpfiles: ``True`` to delete the file when closed.
+    :return: Handle for the created file.
     """
     content_encoded = content.encode("utf-8") if not isinstance(content, bytes) else content
     content_raw = base64.b64decode(content_encoded) if decode else content_encoded
@@ -957,12 +943,9 @@ class CryptoBackendXMLSecurity(CryptoBackend):
 def security_context(conf):
     """Create a :class:`SecurityContext` based on configuration settings.
 
-    Args:
-        conf: Configuration instance exposing crypto backend attributes.
-
-    Returns:
-        SecurityContext | None: Prepared security context or ``None`` when
-        configuration is missing.
+    :param conf: Configuration instance exposing crypto backend attributes.
+    :return: Prepared security context or ``None`` when configuration is
+        missing.
     """
     if not conf:
         return None
@@ -1781,15 +1764,12 @@ def pre_signature_part(
 ):
     """Create the signature template for an assertion.
 
-    Args:
-        ident: Identifier of the assertion that will be signed.
-        public_key: Optional base64 encoded PEM key data.
-        identifier: Optional signing key identifier.
-        digest_alg: Digest algorithm URI override.
-        sign_alg: Signature algorithm URI override.
-
-    Returns:
-        saml2.ds.Signature: Prepared signature descriptor.
+    :param ident: Identifier of the assertion that will be signed.
+    :param public_key: Optional base64 encoded PEM key data.
+    :param identifier: Optional signing key identifier.
+    :param digest_alg: Digest algorithm URI override.
+    :param sign_alg: Signature algorithm URI override.
+    :return: Prepared signature descriptor.
     """
 
     # XXX

--- a/src/saml2/virtual_org.py
+++ b/src/saml2/virtual_org.py
@@ -13,10 +13,9 @@ class VirtualOrg:
     def __init__(self, sp, vorg, cnf):
         """Initialise helpers for attribute aggregation.
 
-        Args:
-            sp: Service provider client instance.
-            vorg: Name of the virtual organisation.
-            cnf: Virtual organisation configuration dictionary.
+        :param sp: Service provider client instance.
+        :param vorg: Name of the virtual organisation.
+        :param cnf: Virtual organisation configuration dictionary.
         """
         self.sp = sp  # The parent SP client instance
         self._name = vorg
@@ -67,11 +66,9 @@ class VirtualOrg:
     def do_aggregation(self, name_id):
         """Perform attribute aggregation across VO members.
 
-        Args:
-            name_id: Subject identifier whose attributes should be aggregated.
-
-        Returns:
-            bool: ``True`` if at least one member was queried, otherwise
+        :param name_id: Subject identifier whose attributes should be
+            aggregated.
+        :return: ``True`` if at least one member was queried, otherwise
             ``False``.
         """
 


### PR DESCRIPTION
## Summary
- restore the add_path documentation example and return existing docstrings to the original Sphinx-style format
- update helper modules (configuration, utilities, crypto, discovery, etc.) to use consistent :param / :return sections for generated docs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'saml2')*

------
https://chatgpt.com/codex/tasks/task_e_68d59f9735d4832c8ee014f5a91d35fd